### PR TITLE
Improve const-folding for default impl of is_purely_immutable(x)

### DIFF
--- a/src/IsPurelyImmutable.jl
+++ b/src/IsPurelyImmutable.jl
@@ -37,14 +37,14 @@ the meaning of `immutable` in Julia.
 function is_purely_immutable end
 
 # Default implementation that checks for recursively immutable types
-function is_purely_immutable(@nospecialize(x))::Bool
+function is_purely_immutable(@nospecialize(x))
     isbitstype(typeof(x)) ||
         # If not isbitstype, fall back to the generated function (non-isbits structs)
         _nonisbits_is_purely_immutable(x)
 end
 
 # Generated function for non-isbits structs to generate a recursive call over all fields.
-@inline @generated function _nonisbits_is_purely_immutable(x)::Bool
+@inline @generated function _nonisbits_is_purely_immutable(x)
     :(if isimmutable(x)
         # Recursive call to is_purely_immutable for each field of x.
         $([

--- a/src/IsPurelyImmutable.jl
+++ b/src/IsPurelyImmutable.jl
@@ -37,7 +37,7 @@ the meaning of `immutable` in Julia.
 function is_purely_immutable end
 
 # Default implementation that checks for recursively immutable types
-function is_purely_immutable(@nospecialize(x))
+function is_purely_immutable(x)
     isbitstype(typeof(x)) ||
         # If not isbitstype, fall back to the generated function (non-isbits structs)
         _nonisbits_is_purely_immutable(x)


### PR DESCRIPTION
Now this const-folds to directly return just a `Bool` for many more cases:
```julia
julia> @code_typed is_purely_immutable(2.0)
CodeInfo(
1 ─     return true
) => Bool

julia> @code_typed is_purely_immutable([])
CodeInfo(
1 ─     return false
) => Bool

julia> @code_typed is_purely_immutable(([],()))
CodeInfo(
1 ─     goto #3 if not false
2 ─     nothing::Nothing
3 ┄     return false
) => Bool
```

(Note, that last one gets cleaned up by LLVM to just return false):
```julia
julia> @code_llvm debuginfo=:none is_purely_immutable([])

define i8 @julia_is_purely_immutable_16921(%jl_value_t addrspace(10)*) {
top:
  ret i8 0
}
```

After this PR, I _think_ now the only reason to add an overload would be if you want to change the _behavior_ for a type (a struct that behaves weirdly, e.g. a mutable-until-shared struct), and you shouldn't need to add overloads for performance. :)